### PR TITLE
Add voice message recording to chat page

### DIFF
--- a/src/Rise.Client/Components/Chat/ChatInput.razor
+++ b/src/Rise.Client/Components/Chat/ChatInput.razor
@@ -1,4 +1,7 @@
-@* Input met 2 knoppen *@
+@* Input met spraakopname en verzenden *@
+@inject IJSRuntime JS
+@implements IAsyncDisposable
+
 <form class="bg-white border-t border-neutral-200 px-3 py-2" @onsubmit="HandleSubmit">
     <div class="flex items-center gap-2">
         <input id="chat-input"
@@ -8,26 +11,61 @@
                @bind="Value"
                @bind:event="oninput" />
 
-        <button type="button" class="grid place-items-center h-12 w-12 rounded-xl bg-blue-700 hover:bg-blue-800 text-white" title="Bel">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="#ffffff" viewBox="0 0 256 256">
-                <path d="M128,176a48.05,48.05,0,0,0,48-48V64a48,48,0,0,0-96,0v64A48.05,48.05,0,0,0,128,176ZM96,64a32,32,0,0,1,64,0v64a32,32,0,0,1-64,0Zm40,143.6V240a8,8,0,0,1-16,0V207.6A80.11,80.11,0,0,1,48,128a8,8,0,0,1,16,0,64,64,0,0,0,128,0,8,8,0,0,1,16,0A80.11,80.11,0,0,1,136,207.6Z"></path>
-            </svg>
-            <span class="sr-only">Bel</span>
+        <button type="button"
+                class="@VoiceButtonClasses"
+                title="Spraakbericht opnemen"
+                disabled="@(_isProcessing || !_canRecord)"
+                @onclick="ToggleRecordingAsync">
+            @if (_isProcessing)
+            {
+                <svg class="h-6 w-6 animate-spin text-current" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 00-12 12h4z"></path>
+                </svg>
+            }
+            else if (_isRecording)
+            {
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M9 7a3 3 0 016 0v4a3 3 0 11-6 0V7zm-1 4a4 4 0 108 0V7a4 4 0 10-8 0v4zm-1 0a5 5 0 0010 0h1.5a.5.5 0 010 1H15a5 5 0 01-10 0H3.5a.5.5 0 010-1H7zm4 5a7 7 0 01-7-7h1a6 6 0 0012 0h1a7 7 0 01-7 7zm-1 2a1 1 0 112 0v1h3a1 1 0 010 2H7a1 1 0 110-2h3v-1z" />
+                </svg>
+            }
+            else
+            {
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 14a3 3 0 003-3V6a3 3 0 10-6 0v5a3 3 0 003 3zm5-3a5 5 0 01-10 0H5a7 7 0 0014 0h-2zm-5 8a7.002 7.002 0 01-6.32-4H4a1 1 0 100 2h3.09A9.005 9.005 0 0011 22h2a9.005 9.005 0 003.91-5H20a1 1 0 100-2h-1.68A7.002 7.002 0 0112 19z" />
+                </svg>
+            }
+            <span class="sr-only">Spraakbericht opnemen</span>
         </button>
 
-        <button type="submit" class="grid place-items-center h-12 w-12 rounded-xl bg-[#127646] hover:bg-green-800 text-white" title="Verzenden">
+        <button type="submit"
+                class="grid place-items-center h-12 w-12 rounded-xl bg-[#127646] hover:bg-green-800 text-white disabled:opacity-40 disabled:cursor-not-allowed"
+                title="Verzenden"
+                disabled="@string.IsNullOrWhiteSpace(Value)">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="#ffffff" viewBox="0 0 256 256">
                 <path d="M231.87,114l-168-95.89A16,16,0,0,0,40.92,37.34L71.55,128,40.92,218.67A16,16,0,0,0,56,240a16.15,16.15,0,0,0,7.93-2.1l167.92-96.05a16,16,0,0,0,.05-27.89ZM56,224a.56.56,0,0,0,0-.12L85.74,136H144a8,8,0,0,0,0-16H85.74L56.06,32.16A.46.46,0,0,0,56,32l168,95.83Z"></path>
             </svg>
             <span class="sr-only">Verzenden</span>
         </button>
     </div>
+
+    @if (!string.IsNullOrWhiteSpace(_errorMessage))
+    {
+        <p class="mt-2 text-xs text-red-600">@_errorMessage</p>
+    }
 </form>
 
 @code {
     [Parameter] public string? Value { get; set; }
     [Parameter] public EventCallback<string?> ValueChanged { get; set; }
     [Parameter] public EventCallback<string> OnSend { get; set; }
+    [Parameter] public EventCallback<RecordedAudio> OnSendVoice { get; set; }
+
+    private IJSObjectReference? _module;
+    private bool _isRecording;
+    private bool _isProcessing;
+    private bool _canRecord = true;
+    private string? _errorMessage;
 
     private async Task HandleSubmit()
     {
@@ -37,6 +75,148 @@
             await OnSend.InvokeAsync(text);
             Value = string.Empty;
             await ValueChanged.InvokeAsync(Value);
+        }
+    }
+
+    private async Task ToggleRecordingAsync()
+    {
+        if (_isProcessing)
+        {
+            return;
+        }
+
+        if (!_isRecording)
+        {
+            await StartRecordingAsync();
+        }
+        else
+        {
+            await CompleteRecordingAsync();
+        }
+    }
+
+    private async Task StartRecordingAsync()
+    {
+        if (!OnSendVoice.HasDelegate)
+        {
+            _errorMessage = "Spraakberichten worden niet ondersteund.";
+            StateHasChanged();
+            return;
+        }
+
+        _errorMessage = null;
+
+        try
+        {
+            await EnsureModuleAsync();
+            await _module!.InvokeVoidAsync("startRecording");
+            _isRecording = true;
+        }
+        catch (JSException ex)
+        {
+            Console.Error.WriteLine(ex);
+            _errorMessage = "Kon de microfoon niet starten. Controleer je browserinstellingen.";
+            _canRecord = false;
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task CompleteRecordingAsync()
+    {
+        if (_module is null)
+        {
+            _isRecording = false;
+            return;
+        }
+
+        _isProcessing = true;
+        StateHasChanged();
+
+        try
+        {
+            var audio = await _module.InvokeAsync<RecordedAudio?>("stopRecording");
+            if (audio is not null && !string.IsNullOrWhiteSpace(audio.DataUrl))
+            {
+                _errorMessage = null;
+                if (OnSendVoice.HasDelegate)
+                {
+                    await OnSendVoice.InvokeAsync(audio);
+                }
+            }
+        }
+        catch (JSException ex)
+        {
+            Console.Error.WriteLine(ex);
+            _errorMessage = "Het opnemen van audio is mislukt.";
+        }
+        finally
+        {
+            _isRecording = false;
+            _isProcessing = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task EnsureModuleAsync()
+    {
+        _module ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/voiceRecorder.js");
+    }
+
+    private string VoiceButtonClasses
+    {
+        get
+        {
+            var classes = new List<string>
+            {
+                "grid",
+                "place-items-center",
+                "h-12",
+                "w-12",
+                "rounded-xl",
+                "transition",
+                "text-white"
+            };
+
+            if (!_canRecord)
+            {
+                classes.AddRange(new[] { "bg-neutral-300", "text-neutral-500" });
+            }
+            else if (_isRecording)
+            {
+                classes.AddRange(new[] { "bg-red-600", "hover:bg-red-700", "animate-pulse" });
+            }
+            else
+            {
+                classes.AddRange(new[] { "bg-blue-700", "hover:bg-blue-800" });
+            }
+
+            if (_isProcessing)
+            {
+                classes.AddRange(new[] { "opacity-75", "cursor-wait" });
+            }
+
+            classes.Add("disabled:opacity-50");
+            classes.Add("disabled:cursor-not-allowed");
+
+            return string.Join(' ', classes);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module is not null)
+        {
+            try
+            {
+                await _module.InvokeVoidAsync("disposeRecorder");
+            }
+            catch (JSException)
+            {
+                // ignore disposal exceptions
+            }
+
+            await _module.DisposeAsync();
         }
     }
 }

--- a/src/Rise.Client/Components/Chat/MessageBubble.razor
+++ b/src/Rise.Client/Components/Chat/MessageBubble.razor
@@ -2,8 +2,8 @@
 @if (IsOutgoing)
 {
     <div class="flex justify-end">
-        <div class="bg-[#127646] text-white rounded-2xl rounded-tr-none px-4 py-2 text-sm shadow-sm max-w-[80%]">
-            @Text
+        <div class="@OutgoingBubbleClasses">
+            @RenderContent()
         </div>
     </div>
 }
@@ -14,8 +14,9 @@ else
         {
             <img src="@AvatarUrl" alt="" class="h-7 w-7 rounded-full" />
         }
-        <div class="bg-white rounded-2xl rounded-tl-none px-4 py-2 shadow-sm text-sm max-w-[80%]">
-            @Text
+
+        <div class="@IncomingBubbleClasses">
+            @RenderContent()
         </div>
     </div>
 }
@@ -24,4 +25,57 @@ else
     [Parameter] public string Text { get; set; } = "";
     [Parameter] public bool IsOutgoing { get; set; }
     [Parameter] public string? AvatarUrl { get; set; }
+    [Parameter] public string? AudioUrl { get; set; }
+    [Parameter] public TimeSpan? AudioDuration { get; set; }
+
+    private RenderFragment RenderContent() => builder =>
+    {
+        var seq = 0;
+        if (!string.IsNullOrWhiteSpace(AudioUrl))
+        {
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "flex flex-col gap-2");
+
+            builder.OpenElement(seq++, "audio");
+            builder.AddAttribute(seq++, "class", "w-52 max-w-full");
+            builder.AddAttribute(seq++, "controls", true);
+            builder.AddAttribute(seq++, "src", AudioUrl);
+            builder.AddAttribute(seq++, "preload", "metadata");
+            builder.CloseElement();
+
+            if (DurationLabel is not null)
+            {
+                builder.OpenElement(seq++, "span");
+                builder.AddAttribute(seq++, "class", "text-[10px] uppercase tracking-wide text-neutral-500");
+                builder.AddContent(seq++, DurationLabel);
+                builder.CloseElement();
+            }
+
+            if (!string.IsNullOrWhiteSpace(Text))
+            {
+                builder.OpenElement(seq++, "p");
+                builder.AddAttribute(seq++, "class", "text-sm");
+                builder.AddContent(seq++, Text);
+                builder.CloseElement();
+            }
+
+            builder.CloseElement();
+        }
+        else
+        {
+            builder.AddContent(seq++, Text);
+        }
+    };
+
+    private string IncomingBubbleClasses => !string.IsNullOrWhiteSpace(AudioUrl)
+        ? "bg-white rounded-2xl rounded-tl-none px-4 py-3 shadow-sm text-sm max-w-[80%]"
+        : "bg-white rounded-2xl rounded-tl-none px-4 py-2 shadow-sm text-sm max-w-[80%]";
+
+    private string OutgoingBubbleClasses => !string.IsNullOrWhiteSpace(AudioUrl)
+        ? "bg-white rounded-2xl rounded-tr-none px-4 py-3 shadow-sm text-sm max-w-[80%]"
+        : "bg-[#127646] text-white rounded-2xl rounded-tr-none px-4 py-2 text-sm shadow-sm max-w-[80%]";
+
+    private string? DurationLabel => AudioDuration is { TotalSeconds: > 0 } duration
+        ? duration.ToString(@"m\:ss")
+        : null;
 }

--- a/src/Rise.Client/Components/Chat/MessageList.razor
+++ b/src/Rise.Client/Components/Chat/MessageList.razor
@@ -11,7 +11,9 @@
     {
         <MessageBubble Text="@m.Text"
                        IsOutgoing="@m.IsOutgoing"
-                       AvatarUrl="@(m.IsOutgoing ? null : m.AvatarUrl)" />
+                       AvatarUrl="@(m.IsOutgoing ? null : m.AvatarUrl)"
+                       AudioUrl="@m.AudioUrl"
+                       AudioDuration="@m.AudioDuration" />
     }
 </section>
 

--- a/src/Rise.Client/Components/Chat/RecordedAudio.cs
+++ b/src/Rise.Client/Components/Chat/RecordedAudio.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Rise.Client.Components.Chat;
+
+public sealed record RecordedAudio
+{
+    [JsonPropertyName("dataUrl")]
+    public string DataUrl { get; init; } = string.Empty;
+
+    [JsonPropertyName("durationSeconds")]
+    public double DurationSeconds { get; init; }
+}

--- a/src/Rise.Client/Pages/Chat.razor
+++ b/src/Rise.Client/Pages/Chat.razor
@@ -13,7 +13,7 @@
 
 <SuggestionChips Suggestions="@_suggestions" OnPick="InsertSuggestion" />
 
-<ChatInput @bind-Value="_draft" OnSend="SendAsync" />
+<ChatInput @bind-Value="_draft" OnSend="SendAsync" OnSendVoice="SendVoiceAsync" />
 
 @code {
     private readonly List<Message> _messages =
@@ -62,10 +62,21 @@
 
     private Task SendAsync(string text)
     {
- 
+
         var censored = Filter.Censor(text);
 
         _messages.Add(new Message(Guid.NewGuid().ToString(), censored, true, null, DateTimeOffset.Now));
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    private Task SendVoiceAsync(RecordedAudio audio)
+    {
+        TimeSpan? duration = double.IsFinite(audio.DurationSeconds) && audio.DurationSeconds > 0
+            ? TimeSpan.FromSeconds(audio.DurationSeconds)
+            : null;
+
+        _messages.Add(new Message(Guid.NewGuid().ToString(), string.Empty, true, null, DateTimeOffset.Now, audio.DataUrl, duration));
         StateHasChanged();
         return Task.CompletedTask;
     }

--- a/src/Rise.Client/wwwroot/js/voiceRecorder.js
+++ b/src/Rise.Client/wwwroot/js/voiceRecorder.js
@@ -1,0 +1,122 @@
+let mediaRecorder = null;
+let mediaStream = null;
+let recordedChunks = [];
+
+export async function startRecording() {
+    if (mediaRecorder?.state === "recording") {
+        return;
+    }
+
+    if (!navigator.mediaDevices?.getUserMedia) {
+        throw new Error("Audio opnemen wordt niet ondersteund door deze browser.");
+    }
+
+    mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const mimeType = getSupportedMimeType();
+
+    recordedChunks = [];
+    mediaRecorder = new MediaRecorder(mediaStream, mimeType ? { mimeType } : undefined);
+
+    mediaRecorder.ondataavailable = (event) => {
+        if (event.data && event.data.size > 0) {
+            recordedChunks.push(event.data);
+        }
+    };
+
+    mediaRecorder.start();
+}
+
+export async function stopRecording() {
+    if (!mediaRecorder) {
+        return null;
+    }
+
+    if (mediaRecorder.state === "inactive") {
+        cleanup();
+        return null;
+    }
+
+    const stopPromise = new Promise((resolve) => {
+        mediaRecorder.onstop = () => resolve();
+    });
+
+    mediaRecorder.stop();
+    await stopPromise;
+
+    const blob = new Blob(recordedChunks, { type: mediaRecorder.mimeType });
+    cleanup();
+
+    if (!blob.size) {
+        return null;
+    }
+
+    const arrayBuffer = await blob.arrayBuffer();
+    const base64 = await bufferToBase64(arrayBuffer);
+
+    let durationSeconds = 0;
+    try {
+        const audioContext = new AudioContext();
+        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer.slice(0));
+        durationSeconds = audioBuffer.duration;
+        await audioContext.close();
+    } catch (error) {
+        console.warn("Kon audio niet decoderen", error);
+    }
+
+    return {
+        dataUrl: `data:${blob.type};base64,${base64}`,
+        durationSeconds
+    };
+}
+
+export function disposeRecorder() {
+    if (mediaRecorder?.state === "recording") {
+        mediaRecorder.stop();
+    }
+
+    cleanup();
+}
+
+function cleanup() {
+    if (mediaRecorder) {
+        mediaRecorder.ondataavailable = null;
+        mediaRecorder.onstop = null;
+        mediaRecorder = null;
+    }
+
+    if (mediaStream) {
+        mediaStream.getTracks().forEach((track) => track.stop());
+        mediaStream = null;
+    }
+
+    recordedChunks = [];
+}
+
+function getSupportedMimeType() {
+    const possibleTypes = [
+        "audio/webm;codecs=opus",
+        "audio/ogg;codecs=opus",
+        "audio/webm"
+    ];
+
+    for (const type of possibleTypes) {
+        if (MediaRecorder.isTypeSupported(type)) {
+            return type;
+        }
+    }
+
+    return null;
+}
+
+async function bufferToBase64(buffer) {
+    let binary = "";
+    const bytes = new Uint8Array(buffer);
+    const chunkSize = 0x8000;
+
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+        const chunk = bytes.subarray(i, Math.min(i + chunkSize, bytes.length));
+        binary += String.fromCharCode(...chunk);
+    }
+
+    return btoa(binary);
+}

--- a/src/Rise.Shared/Chat/Message.cs
+++ b/src/Rise.Shared/Chat/Message.cs
@@ -5,5 +5,7 @@ public sealed record Message(
     string Text,
     bool IsOutgoing,
     string? AvatarUrl = null,
-    DateTimeOffset? Timestamp = null
+    DateTimeOffset? Timestamp = null,
+    string? AudioUrl = null,
+    TimeSpan? AudioDuration = null
 );


### PR DESCRIPTION
## Summary
- add a microphone control to the chat input with JS interop to record and submit voice messages
- extend the shared chat message model and message bubbles to support audio playback with optional duration labels
- provide a browser-side recorder module to capture audio, encode it, and return it to Blazor for rendering

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e6318edc2483319e9e8619cfa8b66f