### PR TITLE
Add local video call preview page

### DIFF
--- a/src/Rise.Client/Layout/NavBar.razor
+++ b/src/Rise.Client/Layout/NavBar.razor
@@ -26,6 +26,9 @@
       <NavLink class="navbar-item" href="product">
         Products
       </NavLink>
+      <NavLink class="navbar-item" href="videocall">
+        Videobellen
+      </NavLink>
       <AuthorizeView>
         <Authorized>
           <NavLink class="navbar-item" href="private">

--- a/src/Rise.Client/Pages/VideoCall.razor
+++ b/src/Rise.Client/Pages/VideoCall.razor
@@ -1,0 +1,143 @@
+@page "/videocall"
+@implements IAsyncDisposable
+@inject IJSRuntime JsRuntime
+
+<h1 class="title">Videobellen (lokaal prototype)</h1>
+<p class="subtitle">
+    Test hier de lokale videobelervaring. We gebruiken enkel je eigen camera en microfoon en sturen nog geen media naar andere deelnemers.
+</p>
+
+@if (!_hasDeviceSupport)
+{
+    <div class="notification is-danger" role="alert">
+        Je browser ondersteunt geen videobellen via WebRTC. Probeer een recente versie van Chrome, Edge of Firefox.
+    </div>
+}
+else
+{
+    <div class="video-call-container">
+        <section>
+            <h2 class="title is-5">Lokale preview</h2>
+            <p class="content">
+                Start de preview om je camera en microfoon lokaal te testen. De stream verlaat je browser niet.
+            </p>
+            <div class="video-preview-wrapper">
+                <video @ref="_localVideo" class="video-preview" autoplay muted></video>
+            </div>
+        </section>
+
+        <section class="video-controls">
+            <button class="button is-primary" @onclick="StartPreviewAsync" disabled="@(!_hasDeviceSupport || _isBusy || _isPreviewActive)">
+                Start preview
+            </button>
+            <button class="button is-light" @onclick="StopPreviewAsync" disabled="@(!_hasDeviceSupport || _isBusy || !_isPreviewActive)">
+                Stop
+            </button>
+        </section>
+
+        @if (!string.IsNullOrWhiteSpace(_errorMessage))
+        {
+            <div class="notification is-warning" role="alert">@_errorMessage</div>
+        }
+
+        <section>
+            <h2 class="title is-5">Volgende stappen</h2>
+            <p class="content">
+                Later kan je deze pagina uitbreiden met SignalR voor het opzetten van peer-to-peer verbindingen en het delen van streams tussen gebruikers.
+                Het domeinmodel kan hiervoor sessies, deelnemers en hun toestandsmachines bevatten. Momenteel beperken we ons tot het lokaal tonen van de media stream.
+            </p>
+        </section>
+    </div>
+}
+
+@code {
+    private ElementReference _localVideo;
+    private IJSObjectReference? _module;
+    private bool _hasDeviceSupport = true;
+    private bool _isPreviewActive;
+    private bool _isBusy;
+    private string? _errorMessage;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        _module = await JsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/videoCall.js");
+        _hasDeviceSupport = await _module.InvokeAsync<bool>("hasDeviceSupport");
+        StateHasChanged();
+    }
+
+    private async Task StartPreviewAsync()
+    {
+        if (_module is null)
+        {
+            return;
+        }
+
+        _errorMessage = null;
+        _isBusy = true;
+
+        try
+        {
+            await _module.InvokeVoidAsync("startLocalPreview", _localVideo);
+            _isPreviewActive = true;
+        }
+        catch (JSException ex)
+        {
+            _errorMessage = ex.Message;
+        }
+        finally
+        {
+            _isBusy = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task StopPreviewAsync()
+    {
+        if (_module is null)
+        {
+            return;
+        }
+
+        _errorMessage = null;
+        _isBusy = true;
+
+        try
+        {
+            await _module.InvokeVoidAsync("stopLocalPreview", _localVideo);
+        }
+        catch (JSException ex)
+        {
+            _errorMessage = ex.Message;
+        }
+        finally
+        {
+            _isBusy = false;
+            _isPreviewActive = false;
+            StateHasChanged();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _module.InvokeVoidAsync("stopLocalPreview", _localVideo);
+        }
+        catch (JSException)
+        {
+            // In dit stadium negeren we fouten bij het opruimen van de lokale stream.
+        }
+
+        await _module.DisposeAsync();
+    }
+}

--- a/src/Rise.Client/Styles/app.css
+++ b/src/Rise.Client/Styles/app.css
@@ -5,3 +5,46 @@
    @import "tailwindcss" source("./"); */
 
 /* Jouw extra CSS hieronder */
+
+.video-call-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    margin: 2rem auto;
+    max-width: 960px;
+}
+
+.video-preview-wrapper {
+    position: relative;
+    background-color: #111;
+    border-radius: 1rem;
+    overflow: hidden;
+    min-height: 240px;
+}
+
+.video-preview {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    background-color: #000;
+}
+
+.video-controls {
+    display: flex;
+    gap: 1rem;
+}
+
+.video-controls .button {
+    min-width: 160px;
+}
+
+@media (max-width: 600px) {
+    .video-call-container {
+        margin: 1rem;
+    }
+
+    .video-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/src/Rise.Client/wwwroot/js/videoCall.js
+++ b/src/Rise.Client/wwwroot/js/videoCall.js
@@ -1,0 +1,58 @@
+const activeStreams = new WeakMap();
+
+function ensureVideoElement(videoElement) {
+    if (!videoElement) {
+        throw new Error("Geen video-element gevonden om de stream te tonen.");
+    }
+    if (videoElement.tagName?.toLowerCase() !== "video") {
+        throw new Error("Het opgegeven element is geen <video> element.");
+    }
+
+    videoElement.setAttribute("playsinline", "true");
+    videoElement.muted = true;
+}
+
+export function hasDeviceSupport() {
+    return typeof navigator !== "undefined"
+        && typeof navigator.mediaDevices !== "undefined"
+        && typeof navigator.mediaDevices.getUserMedia === "function";
+}
+
+export async function startLocalPreview(videoElement) {
+    ensureVideoElement(videoElement);
+
+    await stopLocalPreview(videoElement);
+
+    if (!hasDeviceSupport()) {
+        throw new Error("Deze browser ondersteunt geen camera- of microfoonopnames.");
+    }
+
+    const constraints = {
+        audio: true,
+        video: {
+            width: { ideal: 1280 },
+            height: { ideal: 720 },
+            facingMode: "user"
+        }
+    };
+
+    const stream = await navigator.mediaDevices.getUserMedia(constraints);
+    videoElement.srcObject = stream;
+    await videoElement.play();
+    activeStreams.set(videoElement, stream);
+}
+
+export async function stopLocalPreview(videoElement) {
+    const stream = activeStreams.get(videoElement);
+    if (stream) {
+        stream.getTracks().forEach(track => track.stop());
+        activeStreams.delete(videoElement);
+    }
+
+    if (videoElement) {
+        if (videoElement.srcObject) {
+            videoElement.pause?.();
+        }
+        videoElement.srcObject = null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Blazor page that demonstrates a local-only video call preview and outlines next steps for SignalR integration
- create a JavaScript module to manage WebRTC camera/microphone streams and add responsive styling
- expose the prototype through the main navigation for easy discovery

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e6396381788331a5d0b7d10bf820f1